### PR TITLE
HTTP getsalt

### DIFF
--- a/keybase-chat-gtk.cabal
+++ b/keybase-chat-gtk.cabal
@@ -24,8 +24,14 @@ source-repository head
 
 common shared-opts
   default-extensions:
-      NoImplicitPrelude
+      BlockArguments
+    , FlexibleContexts
+    , GADTs
+    , KindSignatures
+    , LambdaCase
+    , NoImplicitPrelude
     , OverloadedStrings
+    , ScopedTypeVariables
   build-depends:
       base ^>=4.12
     , zenhack-prelude ^>=0.1
@@ -43,11 +49,19 @@ common shared-opts
 
 library keybase-chat-api
   import: shared-opts
+  build-depends:
+    bytestring ^>= 0.10.8,
+    http-client ^>= 0.6.4,
+    http-client-tls ^>= 0.3.5,
+    fused-effects ^>= 0.5.0,
+    unliftio ^>= 0.2.12,
   exposed-modules:
       Api
     , Api.Types
     , App
     , Keybase
+    , Keybase.Eff.Http
+    , Keybase.Prelude
   hs-source-dirs:      src
 
 executable keybase-chat-gtk

--- a/keybase-chat-gtk.cabal
+++ b/keybase-chat-gtk.cabal
@@ -47,6 +47,7 @@ library keybase-chat-api
       Api
     , Api.Types
     , App
+    , Keybase
   hs-source-dirs:      src
 
 executable keybase-chat-gtk

--- a/keybase-chat-gtk.cabal
+++ b/keybase-chat-gtk.cabal
@@ -25,6 +25,10 @@ source-repository head
 common shared-opts
   default-extensions:
       BlockArguments
+    , DeriveAnyClass
+    , DeriveFunctor
+    , DeriveGeneric
+    , DerivingStrategies
     , FlexibleContexts
     , GADTs
     , KindSignatures
@@ -32,6 +36,7 @@ common shared-opts
     , NoImplicitPrelude
     , OverloadedStrings
     , ScopedTypeVariables
+    , ViewPatterns
   build-depends:
       base ^>=4.12
     , zenhack-prelude ^>=0.1
@@ -53,8 +58,11 @@ library keybase-chat-api
     bytestring ^>= 0.10.8,
     http-client ^>= 0.6.4,
     http-client-tls ^>= 0.3.5,
+    http-types ^>= 0.12.3,
     fused-effects ^>= 0.5.0,
+    scientific ^>= 0.3.6,
     unliftio ^>= 0.2.12,
+    unordered-containers ^>= 0.2.9,
   exposed-modules:
       Api
     , Api.Types

--- a/src/Api/Types.hs
+++ b/src/Api/Types.hs
@@ -28,7 +28,8 @@ import           Prelude         (tail)
 
 newtype Time
     = Time Int64
-    deriving(A.ToJSON, A.FromJSON, Show, Read, Eq, Ord, Bounded)
+    deriving stock (Show, Read, Eq, Ord, Bounded)
+    deriving newtype (A.ToJSON, A.FromJSON)
 
 data ListResult = ListResult
     { listresCoversations :: [Conversation]
@@ -38,7 +39,8 @@ data ListResult = ListResult
 
 newtype ConversationId
     = ConversationId Text
-    deriving(A.ToJSON, A.FromJSON, Show, Read, Eq, Ord)
+    deriving stock (Show, Read, Eq, Ord)
+    deriving newtype (A.ToJSON, A.FromJSON)
 
 data Conversation = Conversation
     { convId      :: ConversationId
@@ -61,15 +63,18 @@ data Channel = Channel
 -- types instead of wrappers around Text.
 newtype MembersType
     = MembersType Text
-    deriving(A.ToJSON, A.FromJSON, Show, Read, Eq, Ord)
+    deriving stock (Show, Read, Eq, Ord)
+    deriving newtype (A.ToJSON, A.FromJSON)
 
 newtype TopicType
     = TopicType Text
-    deriving(A.ToJSON, A.FromJSON, Show, Read, Eq, Ord)
+    deriving stock (Show, Read, Eq, Ord)
+    deriving newtype (A.ToJSON, A.FromJSON)
 
 newtype MsgId
     = MsgId Int64
-    deriving(A.ToJSON, A.FromJSON, Show, Read, Eq, Ord, Bounded)
+    deriving stock (Show, Read, Eq, Ord, Bounded)
+    deriving newtype (A.ToJSON, A.FromJSON)
 
 data Msg = Msg
     { msgId             :: MsgId
@@ -82,11 +87,13 @@ data Msg = Msg
 
 newtype Uid
     = Uid Text
-    deriving(A.ToJSON, A.FromJSON, Show, Read, Eq, Ord)
+    deriving stock (Show, Read, Eq, Ord)
+    deriving newtype (A.ToJSON, A.FromJSON)
 
 newtype DeviceId
     = DeviceId Text
-    deriving(A.ToJSON, A.FromJSON, Show, Read, Eq, Ord)
+    deriving stock (Show, Read, Eq, Ord)
+    deriving newtype (A.ToJSON, A.FromJSON)
 
 data Sender = Sender
     { senderUid        :: Uid

--- a/src/Keybase.hs
+++ b/src/Keybase.hs
@@ -1,0 +1,54 @@
+module Keybase where
+
+import Zhp
+import Data.Text (Text)
+
+import qualified Data.Aeson as Aeson
+
+
+newtype CsrfToken
+  = CsrfToken { unCsrfToken :: Text }
+
+newtype EmailAddress
+  = EmailAddress { unEmailAddress :: Text }
+
+newtype Hexadecimal a
+  = Hexadecimal { unHexadecimal :: a }
+
+newtype Kid
+  = Kid { unKid :: Text }
+
+newtype LoginSession
+  = LoginSession { unLoginSession :: Text }
+
+newtype Password
+  = Password { unPassword :: Text }
+
+newtype Salt
+  = Salt { unSalt :: Hexadecimal Text }
+
+newtype SessionCookie
+  = SessionCookie { unSessionCookie :: Text }
+
+newtype Username
+  = Username { unUsername :: Text }
+
+type User
+  = Aeson.Value
+
+-- | https://keybase.io/docs/api/1.0/call/getsalt
+getsalt
+  :: Either EmailAddress Username
+  -> IO (Salt, CsrfToken, LoginSession)
+getsalt =
+  undefined
+
+-- | https://keybase.io/docs/api/1.0/call/login
+login
+  :: Either EmailAddress Username
+  -> Password
+  -> Salt -- ^ from 'getsalt'
+  -> Kid
+  -> IO (SessionCookie, User)
+login =
+  undefined

--- a/src/Keybase.hs
+++ b/src/Keybase.hs
@@ -1,7 +1,6 @@
 module Keybase where
 
-import Zhp
-import Data.Text (Text)
+import Keybase.Prelude
 
 import qualified Data.Aeson as Aeson
 

--- a/src/Keybase.hs
+++ b/src/Keybase.hs
@@ -1,53 +1,157 @@
 module Keybase where
 
+import Keybase.Eff.Http
 import Keybase.Prelude
 
+import Control.Effect
+import Control.Effect.Error
+import Data.Scientific (floatingOrInteger)
+import Network.HTTP.Client
+import Network.HTTP.Types.Method
+import Network.HTTP.Types.Status
+
 import qualified Data.Aeson as Aeson
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Text.Encoding as Text
 
 
 newtype CsrfToken
   = CsrfToken { unCsrfToken :: Text }
+  deriving stock (Show)
 
 newtype EmailAddress
   = EmailAddress { unEmailAddress :: Text }
+  deriving stock (Show)
 
 newtype Hexadecimal a
   = Hexadecimal { unHexadecimal :: a }
+  deriving stock (Show)
+
+-- | Something went wrong: either a generic non-200 response code, or some
+-- custom error response.
+data KeybaseError
+  = KeybaseError Request (Response LazyByteString)
+  deriving stock (Show)
 
 newtype Kid
   = Kid { unKid :: Text }
+  deriving stock (Show)
 
 newtype LoginSession
   = LoginSession { unLoginSession :: Text }
+  deriving stock (Show)
 
 newtype Password
   = Password { unPassword :: Text }
+  deriving stock (Show)
+
+newtype PwhVersion
+  = PwhVersion { unPwhVersion :: Int }
+  deriving stock (Show)
 
 newtype Salt
   = Salt { unSalt :: Hexadecimal Text }
+  deriving stock (Show)
 
 newtype SessionCookie
   = SessionCookie { unSessionCookie :: Text }
+  deriving stock (Show)
 
 newtype Username
   = Username { unUsername :: Text }
+  deriving stock (Show)
+
+newtype Uid
+  = Uid { unUid :: Hexadecimal Text }
+  deriving stock (Show)
 
 type User
   = Aeson.Value
 
+defaultKeybaseRequest :: Request
+defaultKeybaseRequest =
+  defaultRequest
+    { host = "keybase.io"
+    , port = 443
+    , secure = True
+    }
+
 -- | https://keybase.io/docs/api/1.0/call/getsalt
+--
+-- @
+-- :l Keybase
+-- getsalt (Right (Username "mitchellsalad")) & runHttp & runError & runError & runError & runM :: IO (Either FlakeyNetwork (Either HttpException (Either KeybaseError (CsrfToken, LoginSession, Salt, Uid))))
+-- @
 getsalt
-  :: Either EmailAddress Username
-  -> IO (Salt, CsrfToken, LoginSession)
-getsalt =
-  undefined
+  :: ( Carrier sig m
+     , Member (Error FlakeyNetwork) sig
+     , Member (Error HttpException) sig
+     , Member (Error KeybaseError) sig
+     , Member HttpEffect sig
+     , MonadIO m
+     )
+  => Either EmailAddress Username
+  -> m (CsrfToken, LoginSession, Salt, Uid)
+getsalt emailAddressOrUsername = do
+  response :: Response LazyByteString <-
+    sendHttpRequest request
+
+  maybe (throwError (KeybaseError request response)) pure do
+    guard (responseStatus response == status200)
+
+    Aeson.Object object <-
+      Aeson.decode (responseBody response)
+
+    Aeson.Object statusObject <-
+      HashMap.lookup "status" object
+
+    Aeson.Number 0 <-
+      HashMap.lookup "code" statusObject
+
+    Aeson.String csrfToken <-
+      HashMap.lookup "csrf_token" object
+
+    Aeson.String loginSession <-
+      HashMap.lookup "login_session" object
+
+    Aeson.Number (floatingOrInteger -> Right pwhVersion) <-
+      HashMap.lookup "pwh_version" object
+
+    Aeson.String salt <-
+      HashMap.lookup "salt" object
+
+    Aeson.String uid <-
+      HashMap.lookup "uid" object
+
+    pure
+      ( CsrfToken csrfToken
+      , LoginSession loginSession
+      , Salt (Hexadecimal salt)
+      , Uid (Hexadecimal uid)
+      )
+
+  where
+    slug :: ByteString
+    slug =
+      Text.encodeUtf8 (either id id (coerce emailAddressOrUsername))
+
+    request :: Request
+    request =
+      defaultKeybaseRequest
+        { method = methodGet
+        , path = "/_/api/1.0/getsalt.json"
+        }
+        & setQueryString [("email_or_username", Just slug)]
 
 -- | https://keybase.io/docs/api/1.0/call/login
 login
-  :: Either EmailAddress Username
+  :: ( Carrier sig m
+     , Member HttpEffect sig
+     )
+  => Either EmailAddress Username
   -> Password
   -> Salt -- ^ from 'getsalt'
   -> Kid
-  -> IO (SessionCookie, User)
+  -> m (SessionCookie, User)
 login =
   undefined

--- a/src/Keybase/Eff/Http.hs
+++ b/src/Keybase/Eff/Http.hs
@@ -1,0 +1,71 @@
+module Keybase.Eff.Http
+  ( HttpEffect
+  , runHttp
+  ) where
+
+import Keybase.Prelude
+
+import Control.Effect
+import Control.Effect.Carrier
+import Control.Effect.Error
+import Control.Effect.Interpret
+import Network.HTTP.Client
+import Network.HTTP.Client.TLS (getGlobalManager)
+import UnliftIO.Exception (try)
+
+
+data HttpEffect (m :: Type -> Type) (k :: Type) where
+  SendHttpRequest
+    :: Request
+    -> (Either HttpException (Response LazyByteString) -> m k)
+    -> HttpEffect m k
+
+-- | Send an HTTP request and receive the response. 'Nothing' indicates network
+-- flakiness. All other exceptions, most of which indicate the server is
+-- misbehaving, are thrown in the 'Error' effect.
+sendHttpRequest
+  :: forall sig m.
+     ( Carrier sig m
+     , Member (Error HttpException) sig
+     , Member HttpEffect sig
+     )
+  => Request
+  -> m (Maybe (Response LazyByteString))
+sendHttpRequest request =
+  send (SendHttpRequest request f)
+  where
+    f
+      :: Either HttpException (Response LazyByteString)
+      -> m (Maybe (Response LazyByteString))
+    f = \case
+      Left ex ->
+        case ex of
+          -- These HTTP exceptions seem normal and all indicate a flakey
+          -- connection, translate them all to Nothing.
+          HttpExceptionRequest _ ResponseTimeout -> pure Nothing
+          HttpExceptionRequest _ ConnectionTimeout -> pure Nothing
+          HttpExceptionRequest _ (ConnectionFailure _) -> pure Nothing
+
+          -- Everything else looks crazy and should never occur, throw them in
+          -- the Error effect.
+          _ -> throwError ex
+
+
+      Right response ->
+        pure (Just response)
+
+-- | Discharge the 'HttpEffect' using the convenient global TLS manager.
+runHttp
+  :: MonadIO m
+  => InterpretC HttpEffect m a
+  -> m a
+runHttp =
+  runInterpret \case
+    SendHttpRequest request next -> do
+      manager :: Manager <-
+        liftIO getGlobalManager
+
+      response :: Either HttpException (Response LazyByteString) <-
+        liftIO (try (httpLbs (setRequestIgnoreStatus request) manager))
+
+      next response

--- a/src/Keybase/Prelude.hs
+++ b/src/Keybase/Prelude.hs
@@ -1,0 +1,13 @@
+module Keybase.Prelude
+  ( LazyByteString
+  , module X
+  ) where
+
+import Data.Kind as X (Type)
+import Data.Text as X (Text)
+import Zhp as X
+
+import qualified Data.ByteString.Lazy
+
+type LazyByteString
+  = Data.ByteString.Lazy.ByteString

--- a/src/Keybase/Prelude.hs
+++ b/src/Keybase/Prelude.hs
@@ -3,8 +3,11 @@ module Keybase.Prelude
   , module X
   ) where
 
+import Data.ByteString as X (ByteString)
+import Data.Coerce as X (coerce)
 import Data.Kind as X (Type)
 import Data.Text as X (Text)
+import GHC.Generics as X (Generic, Generic1)
 import Zhp as X
 
 import qualified Data.ByteString.Lazy


### PR DESCRIPTION
This patch begins adding an HTTP keybase client, following https://keybase.io/docs/api/1.0

I have temporarily defined a few new modules, 

```
Keybase
Keybase.Eff.HTTP
Keybase.Prelude
```

but at some point the types in `Keybase` should be merged with `Api.Types`.